### PR TITLE
Reduce account fetches, add TODO for resolving sync

### DIFF
--- a/src/components/AdventurePopup/PreviewOttoStep.tsx
+++ b/src/components/AdventurePopup/PreviewOttoStep.tsx
@@ -148,7 +148,6 @@ export default function PreviewOttoStep({ onRequestClose }: { onRequestClose: ()
 
       const abortController = new AbortController()
       const timer = setTimeout(() => {
-        console.log('previewottostep using preview adventure otto')
         ottosRepo
           .withAbortSignal(abortController.signal)
           .previewAdventureOtto(otto.id, location.id, actions)

--- a/src/components/AdventurePopup/PreviewOttoStep.tsx
+++ b/src/components/AdventurePopup/PreviewOttoStep.tsx
@@ -125,10 +125,7 @@ export default function PreviewOttoStep({ onRequestClose }: { onRequestClose: ()
   )
 
   const actions = useMemo(() => {
-    if (!otto) {
-      return []
-    }
-    const actions = equippedItemActions.slice()
+    const actions = equippedItemActions ? equippedItemActions.slice() : []
     Object.keys(usedPotionAmounts).forEach(potion => {
       const amount = usedPotionAmounts[potion]
       for (let i = 0; i < amount; i++) {
@@ -140,7 +137,7 @@ export default function PreviewOttoStep({ onRequestClose }: { onRequestClose: ()
       }
     })
     return actions
-  }, [equippedItemActions, usedPotionAmounts, otto])
+  }, [equippedItemActions, usedPotionAmounts])
 
   useEffect(() => {
     if (otto && location) {

--- a/src/components/OttoItemsPopup/index.tsx
+++ b/src/components/OttoItemsPopup/index.tsx
@@ -132,7 +132,7 @@ export default memo(function OttoItemsPopup({ className, maxWidth, height, onReq
   const { traitType } = useTrait()
   const { t } = useTranslation('', { keyPrefix: 'ottoItemsPopup' })
   // eslint-disable-next-line prefer-const
-  let { items, refetch } = useMyItems()
+  let { items } = useMyItems()
   items = useAdventurePreviewItems(items, draftOtto)
   const [selectedItemId, selectItem] = useState<string>()
   const filteredItems = items.filter(item => item.metadata.type === traitType)
@@ -160,12 +160,6 @@ export default memo(function OttoItemsPopup({ className, maxWidth, height, onReq
       from_otto_id: 0,
     })
   }, [otherActions, selectedItemMetadata])
-
-  useEffect(() => {
-    if (show) {
-      refetch()
-    }
-  }, [draftOtto?.id, show, refetch])
 
   const isTraitTypeTruthy = Boolean(traitType)
 

--- a/src/components/OttoPopup/index.tsx
+++ b/src/components/OttoPopup/index.tsx
@@ -16,7 +16,6 @@ const StyledAdventureFullscreen = styled(AdventureFullscreen)`
 
 export default withOtto(
   withTrait(function OttoPopup() {
-    const { refetch: refreshMyItems } = useMyItems()
     const { setOtto, resetEquippedItems } = useOtto()
     const dispatch = useDispatch()
     const ottoTokenId = useSelector(selectOttoPopup)
@@ -36,11 +35,9 @@ export default withOtto(
     useEffect(() => {
       if (prevOtto.current && !otto) {
         resetEquippedItems?.()
-      } else if (!prevOtto.current && otto) {
-        refreshMyItems?.()
       }
       prevOtto.current = otto
-    }, [otto, refreshMyItems, resetEquippedItems])
+    }, [otto, resetEquippedItems])
 
     return (
       <StyledAdventureFullscreen show={Boolean(otto)} onRequestClose={closePopup} closeButtonColor="white">

--- a/src/contexts/MyItems.tsx
+++ b/src/contexts/MyItems.tsx
@@ -8,12 +8,12 @@ const MyItemsContext = createContext<{
   items: Item[]
   idToItem: { [k: string]: Item }
   loading: boolean
-  refetch: () => void
+  fetchAccountItems: () => void
 }>({
   items: [],
   idToItem: {},
   loading: false,
-  refetch: noop,
+  fetchAccountItems: noop,
 })
 
 export const MyItemsProvider = ({ children }: PropsWithChildren<object>) => {
@@ -22,13 +22,14 @@ export const MyItemsProvider = ({ children }: PropsWithChildren<object>) => {
   const { account } = useEthers()
   const { items: itemsRepo } = useRepositories()
 
-  const refetch = useCallback(() => {
+  const fetchAccountItems = useCallback(() => {
     if (!account) {
       setLoading(false)
       setItems([])
       return
     }
     setLoading(true)
+    console.log('refetching all account items')
     itemsRepo
       .getAllItemsByAccount(account)
       .then(setItems)
@@ -39,8 +40,10 @@ export const MyItemsProvider = ({ children }: PropsWithChildren<object>) => {
   }, [itemsRepo, account])
 
   useEffect(() => {
-    refetch()
-  }, [itemsRepo, account, refetch])
+    if (!items || !items.length) {
+      fetchAccountItems()
+    }
+  }, [items, fetchAccountItems])
 
   const value = useMemo(() => {
     return {
@@ -50,9 +53,9 @@ export const MyItemsProvider = ({ children }: PropsWithChildren<object>) => {
         return map
       }, {} as { [id: string]: Item }),
       loading,
-      refetch,
+      fetchAccountItems,
     }
-  }, [items, loading, refetch])
+  }, [items, loading, fetchAccountItems])
 
   return <MyItemsContext.Provider value={value}>{children}</MyItemsContext.Provider>
 }

--- a/src/hooks/useAdventurePotion.ts
+++ b/src/hooks/useAdventurePotion.ts
@@ -11,7 +11,7 @@ const potionIdMap = potionIds.reduce(
 
 export default function useAdventurePotion() {
   const [loading, setLoading] = useState(false)
-  const { items, loading: loadingMyItems, refetch: refetchMyItems } = useMyItems()
+  const { items, loading: loadingMyItems } = useMyItems()
 
   const { use, useItemState } = useItem()
 
@@ -37,10 +37,10 @@ export default function useAdventurePotion() {
 
   useEffect(() => {
     if (useItemState.state === 'Success') {
-      refetchMyItems()
+      // TODO: trigger item fetch after API has picked up the tx.
     }
     setLoading(useItemState.state === 'PendingSignature' || useItemState.state === 'Mining')
-  }, [useItemState.state, refetchMyItems])
+  }, [useItemState.state])
 
   return {
     amounts,

--- a/src/views/foundry/ForgeItem.tsx
+++ b/src/views/foundry/ForgeItem.tsx
@@ -233,6 +233,7 @@ export default function ForgeItem({ formula, itemAmounts: itemCounts, refetchMyI
       window.alert(forgeState.status.errorMessage)
       resetForge()
     }
+    // TODO: On forge success refetch items but after API has picked up tx
   }, [forgeState, resetForge])
 
   return (

--- a/src/views/foundry/index.tsx
+++ b/src/views/foundry/index.tsx
@@ -29,7 +29,7 @@ const useForgeFormulas = () => {
 }
 
 const useMyItemAmounts = () => {
-  const { items, refetch: refetchMyItems } = useMyItems()
+  const { items, fetchAccountItems } = useMyItems()
 
   const amounts = useMemo(() => {
     return items
@@ -40,14 +40,14 @@ const useMyItemAmounts = () => {
       }, {} as MyItemAmounts)
   }, [items])
 
-  return { amounts, refetchMyItems }
+  return { amounts, fetchAccountItems }
 }
 
 export default function FoundryView() {
   const { t } = useTranslation('', { keyPrefix: 'foundry' })
   const { OTTO_ITEM, FOUNDRY } = useContractAddresses()
   const forgeFormulas = useForgeFormulas()
-  const { amounts, refetchMyItems } = useMyItemAmounts()
+  const { amounts, fetchAccountItems } = useMyItemAmounts()
 
   useAssetsBundles([BundleName.FoundryPage])
 
@@ -61,7 +61,7 @@ export default function FoundryView() {
         <meta property="og:image" content="/og.jpg" />
       </Head>
       <FoundryHero />
-      <ForgeList formulas={forgeFormulas} itemAmounts={amounts} refetchMyItems={refetchMyItems} />
+      <ForgeList formulas={forgeFormulas} itemAmounts={amounts} refetchMyItems={fetchAccountItems} />
     </ERC1155ApprovalProvider>
   )
 }

--- a/src/views/my-items/MyItemsPage.tsx
+++ b/src/views/my-items/MyItemsPage.tsx
@@ -284,7 +284,7 @@ export default function MyItemsPage() {
   const [selectedItemId, setSelectedItemId] = useState<string>()
   const [usingItemId, setUsingItemId] = useState<string>()
   const [redeemingCouponId, setRedeemingCouponId] = useState<string>()
-  const { items, loading, refetch } = useMyItems()
+  const { items, loading } = useMyItems()
   const selectedItem = useMyItem(selectedItemId)
   const usingItem = useMyItem(usingItemId)
   const redeemingCoupon = useMyItem(redeemingCouponId)
@@ -316,7 +316,7 @@ export default function MyItemsPage() {
           <UseItemPopup
             item={usingItem}
             onClose={() => {
-              refetch()
+              // TODO: trigger item fetch after API has picked up the tx.
               setUsingItemId(undefined)
             }}
           />
@@ -325,7 +325,7 @@ export default function MyItemsPage() {
           <RedeemCouponPopupQuery
             item={redeemingCoupon}
             onClose={() => {
-              refetch()
+              // TODO: trigger item fetch after API has picked up the tx.
               setRedeemingCouponId(undefined)
             }}
           />


### PR DESCRIPTION
* Resolves issue where selecting trait causes refetch
* Account item refetch after item actions turned off. This never worked properly anyway because API frequently is behind the tx success. We could maybe do it but add some amount of delay... But generally already formed habit of refresh manually.